### PR TITLE
Revert PowTargetTimespan

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -76,9 +76,7 @@ public:
         // Value for previous forks
         consensus.preVerthashPowLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
-        consensus.nPowTargetTimespan = 3.5 * 24 * 60 * 60; // 3.5 days
-        // Value for previous forks
-        consensus.nPreKGWPowTargetTimespan = 4 * 60;
+        consensus.nPowTargetTimespan = 4 * 60;
         consensus.nPowTargetSpacing = 1 * 60;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
@@ -188,9 +186,7 @@ public:
         // Value for previous forks
         consensus.preVerthashPowLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
-        consensus.nPowTargetTimespan = 3.5 * 24 * 60 * 60; // 3.5 days
-        // Value for previous forks
-        consensus.nPreKGWPowTargetTimespan = 4 * 60;
+        consensus.nPowTargetTimespan = 4 * 60;
         consensus.nPowTargetSpacing = 1 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
@@ -285,7 +281,6 @@ public:
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.preVerthashPowLimit = consensus.powLimit;
         consensus.nPowTargetTimespan = 3.5 * 24 * 60 * 60; // two weeks
-        consensus.nPreKGWPowTargetTimespan = consensus.nPowTargetTimespan;
         consensus.nPowTargetSpacing = 1 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = true;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -75,9 +75,7 @@ struct Params {
     bool fPowNoRetargeting;
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;
-    int64_t nPreKGWPowTargetTimespan;
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
-    int64_t preDifficultyAdjustmentInterval() const { return nPreKGWPowTargetTimespan / nPowTargetSpacing; }
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;
 };

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -57,7 +57,7 @@ unsigned int GetNextWorkRequired_Scrypt(const CBlockIndex* pindexLast, const CBl
     unsigned int nProofOfWorkLimit = UintToArith256(params.preVerthashPowLimit).GetCompact();
 
     // Only change once per difficulty adjustment interval
-    if ((pindexLast->nHeight+1) % params.preDifficultyAdjustmentInterval() != 0)
+    if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0)
     {
         if (params.fPowAllowMinDifficultyBlocks)
         {
@@ -70,7 +70,7 @@ unsigned int GetNextWorkRequired_Scrypt(const CBlockIndex* pindexLast, const CBl
             {
                 // Return the last non-special-min-difficulty-rules-block
                 const CBlockIndex* pindex = pindexLast;
-                while (pindex->pprev && pindex->nHeight % params.preDifficultyAdjustmentInterval() != 0 && pindex->nBits == nProofOfWorkLimit)
+                while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval() != 0 && pindex->nBits == nProofOfWorkLimit)
                     pindex = pindex->pprev;
                 return pindex->nBits;
             }
@@ -81,9 +81,9 @@ unsigned int GetNextWorkRequired_Scrypt(const CBlockIndex* pindexLast, const CBl
     // Go back by what we want to be 14 days worth of blocks
     // Browncoin: This fixes an issue where a 51% attack can change difficulty at will.
     // Go back the full period unless it's the first retarget after genesis. Code courtesy of Art Forz
-    int blockstogoback = params.preDifficultyAdjustmentInterval()-1;
-    if ((pindexLast->nHeight+1) != params.preDifficultyAdjustmentInterval())
-        blockstogoback = params.preDifficultyAdjustmentInterval();
+    int blockstogoback = params.DifficultyAdjustmentInterval()-1;
+    if ((pindexLast->nHeight+1) != params.DifficultyAdjustmentInterval())
+        blockstogoback = params.DifficultyAdjustmentInterval();
 
     // Go back by what we want to be 14 days worth of blocks
     const CBlockIndex* pindexFirst = pindexLast;
@@ -188,10 +188,10 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
 
     // Limit adjustment step
     int64_t nActualTimespan = pindexLast->GetBlockTime() - nFirstBlockTime;
-    if (nActualTimespan < params.nPreKGWPowTargetTimespan/4)
-        nActualTimespan = params.nPreKGWPowTargetTimespan/4;
-    if (nActualTimespan > params.nPreKGWPowTargetTimespan*4)
-        nActualTimespan = params.nPreKGWPowTargetTimespan*4;
+    if (nActualTimespan < params.nPowTargetTimespan/4)
+        nActualTimespan = params.nPowTargetTimespan/4;
+    if (nActualTimespan > params.nPowTargetTimespan*4)
+        nActualTimespan = params.nPowTargetTimespan*4;
 
     // Retarget
     arith_uint256 bnNew;
@@ -204,7 +204,7 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
     if (fShift)
         bnNew >>= 1;
     bnNew *= nActualTimespan;
-    bnNew /= params.nPreKGWPowTargetTimespan;
+    bnNew /= params.nPowTargetTimespan;
     if (fShift)
         bnNew <<= 1;
 


### PR DESCRIPTION
`nPowTargetTimespan` has nothing to do with KGW and only applies to difficulty of Scrypt blocks.